### PR TITLE
fix: Allow the same prefab for many turret configs

### DIFF
--- a/MoreDefenses/Mod.cs
+++ b/MoreDefenses/Mod.cs
@@ -88,6 +88,11 @@ namespace MoreDefenses
         {
           // Load prefab from asset bundle and apply config
           var prefab = m_assetBundles[turretConfig.bundleName].LoadAsset<GameObject>(turretConfig.prefabPath);
+          var newPrefab = PrefabManager.Instance.CreateClonedPrefab(turretConfig.name, prefab);
+          if (newPrefab != null)
+          {
+            prefab = newPrefab;
+          }
           var turret = prefab.AddComponent<Turret>();
           turret.Initialize(turretConfig);
           var turretPiece = TurretConfig.Convert(prefab, turretConfig);


### PR DESCRIPTION
Fix bug that did not allow you to use the same prefab for multiple different turret configs. Now you can specify turrets with different resource costs and damage values, but utilize the already provided prefabs many times.

An example of using the same prefab is shown below

```json
[
  {
    "name": "Ballista",
    "bundleName": "turrets",
    "prefabPath": "Assets/_Project/Prefabs/MMBallista.prefab",
    "description": "Shoots a projectile dealing damage. Able to hit flying monsters",
    "pieceTable": "Hammer",
    "enabled": true,
    "type": "Projectile",
    "fireInterval": 2,
    "pierceDamage": 16,
    "range": 20,
    "canShootFlying": true,
    "resources": [
      {
        "item": "Bronze",
        "amount": 10
      },
      {
        "item": "RoundLog",
        "amount": 20
      }
    ]
  },
  {
    "name": "Improved Ballista",
    "bundleName": "turrets",
    "prefabPath": "Assets/_Project/Prefabs/MMBallista.prefab",
    "description": "Shoots a projectile dealing damage. Able to hit flying monsters",
    "pieceTable": "Hammer",
    "enabled": true,
    "type": "Projectile",
    "fireInterval": 2,
    "pierceDamage": 30,
    "range": 20,
    "canShootFlying": true,
    "resources": [
      {
        "item": "Iron",
        "amount": 20
      },
      {
        "item": "FineWood",
        "amount": 20
      }
    ]
  }
]
```